### PR TITLE
feat: Add GitHub action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,37 @@
+name: build
+on: [ push, pull_request ]
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    container: public.ecr.aws/ubuntu/ubuntu:21.04
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - run: |
+        apt-get update
+        apt-get install --no-install-recommends -y meson scdoc gcc libc6-dev
+      name: Install build tools
+
+    - run: meson -Dprefix=$(pwd)/out build
+      name: Configure limbo
+
+    - run: ninja -C build install
+      name: Build limbo
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: limbo-binaries-${{ github.run_number }}
+        path: |
+          out
+      name: Upload binaries
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: limbo-logs-${{ github.run_number }}
+        path: |
+          build/meson-logs/
+      name: Upload build logs
+      if: ${{ always() }}


### PR DESCRIPTION
Adds a GitHub CI action to build limbo and publish the binaries. Runs in Ubuntu 21.04 since 20.04 doesn't support user syscall dispatch.